### PR TITLE
fix: improve blog post readability on mobile

### DIFF
--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -38,7 +38,7 @@ const { content } = Astro.props;
   }
 </style>
 
-<article class="prose-slate w-sm md:w-prose md:prose poppins">
+<article class="prose-slate prose w-sm md:w-prose poppins">
   <Button href="/blog/" data-brutal-button data-brutal-hover>&larr; Back to blog</Button>
   <h1 class="mt-8 text-2xl md:text-4xl">{content.title}</h1>
   <p class="published-color text-opacity-50 text-sm md:text-base">


### PR DESCRIPTION
## Summary
- Blog posts read as a dense "wall of text" on mobile: tight line spacing, no gap between paragraphs. Desktop looked fine.
- Root cause: `src/components/blog/BlogContent.astro` applied the UnoCSS typography ruleset as `md:prose` — the actual line-height (1.75) and paragraph spacing (1.25em) rules were gated behind the `md:` (768px) breakpoint, so mobile fell back to bare browser defaults.
- Fix: drop the `md:` prefix so `prose` applies at every width; the responsive width classes (`w-sm` / `md:w-prose`) are unchanged.

## Test plan
- [x] `pnpm run build` — 0 errors/warnings, 215 pages built
- [x] `pnpm run check` (astro check + lint + format) — clean
- [x] Verified in built output that `.prose` paragraph/line-height rules are present with no `@media` wrapper (previously only emitted under `md:`)
- [ ] Visual check on a real mobile viewport (devtools responsive mode) recommended before merge

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)